### PR TITLE
feat: Bolao completo - senha admin, bandeiras, accordion, cadeado e publico por fase

### DIFF
--- a/static/css/bolao.css
+++ b/static/css/bolao.css
@@ -1759,3 +1759,158 @@ body {
         gap: 0.25rem;
     }
 }
+
+/* ===== Badge Error (locked) ===== */
+.badge-error {
+    background: rgba(220, 53, 69, 0.15);
+    color: #dc3545;
+    border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+/* ===== Toggle Lock (cadeado) ===== */
+.config-check:checked + .toggle-slider-lock {
+    background: #dc3545;
+}
+.config-check:checked + .toggle-slider-lock:before {
+    transform: translateX(24px);
+}
+
+/* ===== Toggle Publico ===== */
+.config-check:checked + .toggle-slider-publico {
+    background: #17a2b8;
+}
+.config-check:checked + .toggle-slider-publico:before {
+    transform: translateX(24px);
+}
+
+/* ===== Etapa Accordion ===== */
+.etapa-section {
+    background: var(--card-bg);
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+}
+
+.etapa-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.5rem;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.2s;
+}
+
+.etapa-header:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.etapa-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.etapa-header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.etapa-header-right .toggle-icon {
+    transition: transform 0.3s ease;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.etapa-content {
+    padding: 0 1.5rem 1.5rem;
+}
+
+/* ===== Participante Accordion (publico) ===== */
+.participante-toggle {
+    cursor: pointer;
+    user-select: none;
+}
+
+.participante-toggle:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.participante-toggle h3 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.participante-toggle .toggle-icon {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    transition: transform 0.3s ease;
+}
+
+/* ===== Jogos TBD (a definir) ===== */
+.jogo-tbd {
+    opacity: 0.6;
+}
+
+.tbd-icon {
+    font-size: 1.5rem;
+    color: var(--text-muted);
+}
+
+.tbd-nome {
+    font-style: italic;
+    color: var(--text-muted);
+}
+
+.tbd-vs {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.tbd-desc {
+    text-align: center;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 0.25rem 0 0.5rem;
+}
+
+/* ===== Salvar Eliminatórias ===== */
+.btn-salvar-elim {
+    width: 100%;
+    margin-top: 0.5rem;
+}
+
+.salvar-section {
+    padding: 1rem 0;
+}
+
+/* ===== Alert Error ===== */
+.alert-error {
+    background: rgba(220, 53, 69, 0.1);
+    border: 1px solid rgba(220, 53, 69, 0.3);
+    color: #dc3545;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+}
+
+/* ===== Section Description (admin) ===== */
+.section-desc {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+}
+
+/* ===== Jogo row eliminatórias ===== */
+.jogo-row-elim {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 0.75rem 0;
+}
+
+.jogo-row-elim:last-child {
+    border-bottom: none;
+}

--- a/templates/bolao/admin_eliminatorias.html
+++ b/templates/bolao/admin_eliminatorias.html
@@ -1,5 +1,6 @@
 {% extends 'bolao/base_bolao.html' %}
 {% load static %}
+{% load bolao_filters %}
 
 {% block title %}Admin — Eliminatórias{% endblock %}
 
@@ -49,9 +50,11 @@
                 {% if jogo.selecao_casa and jogo.selecao_fora %}
                 <div class="elim-atual">
                     <span class="badge badge-success">
-                        {{ jogo.selecao_casa.bandeira_emoji }} {{ jogo.selecao_casa.nome }}
+                        <img src="{% static jogo.selecao_casa|flag_url %}" class="bandeira-img-sm" alt="{{ jogo.selecao_casa.codigo }}">
+                        {{ jogo.selecao_casa.nome }}
                         vs
-                        {{ jogo.selecao_fora.nome }} {{ jogo.selecao_fora.bandeira_emoji }}
+                        {{ jogo.selecao_fora.nome }}
+                        <img src="{% static jogo.selecao_fora|flag_url %}" class="bandeira-img-sm" alt="{{ jogo.selecao_fora.codigo }}">
                     </span>
                 </div>
                 {% endif %}
@@ -70,80 +73,96 @@ const TODAS_SELECOES = {{ todas_selecoes|safe }};
 const DEFINIR_URL = '{% url "bolao:admin_definir_equipes" %}';
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Popular selects
     document.querySelectorAll('.elim-select').forEach(select => {
         TODAS_SELECOES.forEach(sel => {
             const opt = document.createElement('option');
             opt.value = sel.id;
             opt.textContent = `${sel.bandeira_emoji} ${sel.nome}`;
+            opt.dataset.codigo = sel.codigo ? sel.codigo.toLowerCase() : '';
             select.appendChild(opt);
         });
+        wrapElimSelectWithFlags(select);
     });
 
-    // Pré-selecionar equipes já definidas
-    document.querySelectorAll('.elim-jogo-row').forEach(row => {
-        const atual = row.querySelector('.elim-atual .badge');
-        if (atual) {
-            // Já tem equipes definidas - elas estão renderizadas no HTML
-        }
-    });
-
-    // Definir equipes
     document.querySelectorAll('.btn-definir-equipes').forEach(btn => {
         btn.addEventListener('click', async function() {
             const jogoId = this.dataset.jogoId;
             const row = this.closest('.elim-jogo-row');
             const casaSelect = row.querySelector('.elim-casa');
             const foraSelect = row.querySelector('.elim-fora');
-
             const casaId = casaSelect.value;
             const foraId = foraSelect.value;
 
-            if (!casaId || !foraId) {
-                showToast('Selecione ambas as equipes', 'error');
-                return;
-            }
-
-            if (casaId === foraId) {
-                showToast('As equipes devem ser diferentes', 'error');
-                return;
-            }
+            if (!casaId || !foraId) { showToast('Selecione ambas as equipes', 'error'); return; }
+            if (casaId === foraId) { showToast('As equipes devem ser diferentes', 'error'); return; }
 
             try {
                 const resp = await fetch(DEFINIR_URL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF_TOKEN },
-                    body: JSON.stringify({
-                        jogo_id: parseInt(jogoId),
-                        selecao_casa_id: parseInt(casaId),
-                        selecao_fora_id: parseInt(foraId),
-                    }),
+                    body: JSON.stringify({ jogo_id: parseInt(jogoId), selecao_casa_id: parseInt(casaId), selecao_fora_id: parseInt(foraId) }),
                 });
                 const result = await resp.json();
                 if (resp.ok) {
                     showToast(result.message, 'success');
                     this.innerHTML = '<i class="fas fa-check-double"></i>';
                     this.style.background = 'var(--success)';
-
-                    // Atualizar badge
                     let badge = row.querySelector('.elim-atual');
-                    const casaNome = casaSelect.options[casaSelect.selectedIndex].textContent;
-                    const foraNome = foraSelect.options[foraSelect.selectedIndex].textContent;
-                    if (!badge) {
-                        badge = document.createElement('div');
-                        badge.className = 'elim-atual';
-                        row.appendChild(badge);
-                    }
-                    badge.innerHTML = `<span class="badge badge-success">${casaNome} vs ${foraNome}</span>`;
+                    const casaSel = TODAS_SELECOES.find(s => s.id == casaId);
+                    const foraSel = TODAS_SELECOES.find(s => s.id == foraId);
+                    const casaCod = casaSel ? casaSel.codigo.toLowerCase() : '';
+                    const foraCod = foraSel ? foraSel.codigo.toLowerCase() : '';
+                    if (!badge) { badge = document.createElement('div'); badge.className = 'elim-atual'; row.appendChild(badge); }
+                    badge.innerHTML = `<span class="badge badge-success"><img src="/static/images/flags/${casaCod}.png" class="bandeira-img-sm"> ${casaSel.nome} vs ${foraSel.nome} <img src="/static/images/flags/${foraCod}.png" class="bandeira-img-sm"></span>`;
                 } else {
                     showToast(result.error, 'error');
                 }
-            } catch (e) {
-                showToast('Erro de conexão', 'error');
-            }
+            } catch (e) { showToast('Erro de conexão', 'error'); }
         });
     });
 });
+
+function wrapElimSelectWithFlags(select) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'custom-select-wrapper';
+    const display = document.createElement('div');
+    display.className = 'custom-select-display';
+    display.innerHTML = '<span class="csd-placeholder">' + select.options[0].text + '</span>';
+    const dropdown = document.createElement('div');
+    dropdown.className = 'custom-select-dropdown';
+
+    TODAS_SELECOES.forEach(sel => {
+        const item = document.createElement('div');
+        item.className = 'custom-select-item';
+        item.dataset.value = sel.id;
+        const cod = sel.codigo ? sel.codigo.toLowerCase() : '';
+        item.innerHTML = `<img src="/static/images/flags/${cod}.png" class="csd-flag" alt="${cod}"> ${sel.nome}`;
+        item.addEventListener('click', () => {
+            select.value = sel.id;
+            select.dispatchEvent(new Event('change'));
+            display.innerHTML = `<img src="/static/images/flags/${cod}.png" class="csd-flag" alt="${cod}"> ${sel.nome}`;
+            dropdown.classList.remove('open');
+            wrapper.classList.remove('open');
+        });
+        dropdown.appendChild(item);
+    });
+
+    display.addEventListener('click', (e) => {
+        e.stopPropagation();
+        document.querySelectorAll('.custom-select-wrapper.open').forEach(w => {
+            if (w !== wrapper) { w.classList.remove('open'); w.querySelector('.custom-select-dropdown').classList.remove('open'); }
+        });
+        dropdown.classList.toggle('open');
+        wrapper.classList.toggle('open');
+    });
+
+    document.addEventListener('click', () => { dropdown.classList.remove('open'); wrapper.classList.remove('open'); });
+
+    select.style.display = 'none';
+    select.parentElement.insertBefore(wrapper, select);
+    wrapper.appendChild(display);
+    wrapper.appendChild(dropdown);
+}
 
 function showToast(message, type) {
     const existing = document.querySelector('.toast');

--- a/templates/bolao/admin_login.html
+++ b/templates/bolao/admin_login.html
@@ -14,9 +14,9 @@
         <form method="post" class="login-form">
             {% csrf_token %}
             <div class="form-group">
-                <label for="admin-pin"><i class="fas fa-key"></i> PIN do Admin</label>
-                <input type="password" name="pin" id="admin-pin" class="form-input"
-                       placeholder="Digite o PIN" inputmode="numeric" maxlength="10" required>
+                <label for="admin-senha"><i class="fas fa-key"></i> Senha do Admin</label>
+                <input type="password" name="senha" id="admin-senha" class="form-input"
+                       placeholder="Digite a senha" maxlength="50" required>
             </div>
             <button type="submit" class="btn btn-primary">
                 <i class="fas fa-unlock"></i> Acessar

--- a/templates/bolao/admin_painel.html
+++ b/templates/bolao/admin_painel.html
@@ -35,15 +35,16 @@
         </div>
     </div>
 
-    <!-- Configurações / Flags -->
+    <!-- Fases Abertas para Palpites -->
     <div class="admin-section">
-        <h3><i class="fas fa-sliders-h"></i> Configurações</h3>
+        <h3><i class="fas fa-sliders-h"></i> Fases Abertas para Palpites</h3>
+        <p class="section-desc">Habilite as fases para que os participantes possam enviar palpites.</p>
         <div class="config-grid">
             <label class="config-toggle">
                 <input type="checkbox" class="config-check" data-campo="fase_grupos_aberta"
                        {% if config.fase_grupos_aberta %}checked{% endif %}>
                 <span class="toggle-slider"></span>
-                <span class="toggle-label">Fase de Grupos Aberta</span>
+                <span class="toggle-label">Fase de Grupos</span>
             </label>
             <label class="config-toggle">
                 <input type="checkbox" class="config-check" data-campo="fase_16avos_aberta"
@@ -81,15 +82,95 @@
                 <span class="toggle-slider"></span>
                 <span class="toggle-label">Final</span>
             </label>
+        </div>
+    </div>
+
+    <!-- Cadeado por fase -->
+    <div class="admin-section">
+        <h3><i class="fas fa-lock"></i> Cadeado por Fase</h3>
+        <p class="section-desc">Quando ativado, nenhum participante poderá enviar ou editar palpites da fase.</p>
+        <div class="config-grid">
             <label class="config-toggle">
-                <input type="checkbox" class="config-check" data-campo="palpites_publicos"
-                       {% if config.palpites_publicos %}checked{% endif %}>
-                <span class="toggle-slider"></span>
-                <span class="toggle-label">Palpites Públicos</span>
+                <input type="checkbox" class="config-check" data-campo="lock_fase_grupos" {% if config.lock_fase_grupos %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Fase de Grupos</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_16avos" {% if config.lock_16avos %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> 16-avos de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_oitavas" {% if config.lock_oitavas %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Oitavas de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_quartas" {% if config.lock_quartas %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Quartas de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_semi" {% if config.lock_semi %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Semifinais</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_terceiro" {% if config.lock_terceiro %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Disputa 3º Lugar</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="lock_final" {% if config.lock_final %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-lock"></span>
+                <span class="toggle-label"><i class="fas fa-lock" style="margin-right:4px;"></i> Final</span>
+            </label>
+        </div>
+    </div>
+
+    <!-- Tornar Público por Fase -->
+    <div class="admin-section">
+        <h3><i class="fas fa-eye"></i> Tornar Palpites Públicos</h3>
+        <p class="section-desc">Libere a visualização pública dos palpites por fase.</p>
+        <div class="config-grid">
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_fase_grupos" {% if config.publico_fase_grupos %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Fase de Grupos</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_16avos" {% if config.publico_16avos %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> 16-avos de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_oitavas" {% if config.publico_oitavas %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Oitavas de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_quartas" {% if config.publico_quartas %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Quartas de Final</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_semi" {% if config.publico_semi %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Semifinais</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_terceiro" {% if config.publico_terceiro %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Disputa 3º Lugar</span>
+            </label>
+            <label class="config-toggle">
+                <input type="checkbox" class="config-check" data-campo="publico_final" {% if config.publico_final %}checked{% endif %}>
+                <span class="toggle-slider toggle-slider-publico"></span>
+                <span class="toggle-label"><i class="fas fa-eye" style="margin-right:4px;"></i> Final</span>
             </label>
         </div>
         <button class="btn btn-primary btn-sm" id="btn-salvar-config" style="margin-top: 1rem;">
-            <i class="fas fa-save"></i> Salvar Configurações
+            <i class="fas fa-save"></i> Salvar Todas as Configurações
         </button>
     </div>
 
@@ -138,9 +219,9 @@
         </a>
     </div>
 
-    <!-- Resultados -->
+    <!-- Resultados Fase de Grupos -->
     <div class="admin-section">
-        <h3><i class="fas fa-futbol"></i> Inserir Resultados</h3>
+        <h3><i class="fas fa-futbol"></i> Resultados — Fase de Grupos</h3>
         <p class="section-desc">Insira os resultados oficiais dos jogos para calcular a pontuação.</p>
 
         {% for grupo in grupos %}
@@ -175,6 +256,46 @@
         </div>
         {% endfor %}
     </div>
+
+    <!-- Resultados Eliminatórias -->
+    {% if fases_elim %}
+    <div class="admin-section">
+        <h3><i class="fas fa-trophy"></i> Resultados — Fases Eliminatórias</h3>
+        <p class="section-desc">Insira os resultados oficiais dos jogos eliminatórios.</p>
+
+        {% for fase in fases_elim %}
+        <div class="resultado-grupo">
+            <h4 class="resultado-grupo-titulo">{{ fase.nome }}</h4>
+            <div class="resultados-list">
+                {% for jogo in fase.jogos %}
+                <div class="resultado-row" data-jogo-id="{{ jogo.id }}">
+                    <div class="resultado-info">
+                        <span class="resultado-data">Jogo {{ jogo.numero_jogo }} — {{ jogo.data_hora|date:"d/m H:i" }}</span>
+                        <span class="resultado-times">
+                            <img src="{% static jogo.selecao_casa|flag_url %}" alt="" class="bandeira-img-sm"> {{ jogo.selecao_casa.nome }}
+                            <span class="vs">vs</span>
+                            {{ jogo.selecao_fora.nome }} <img src="{% static jogo.selecao_fora|flag_url %}" alt="" class="bandeira-img-sm">
+                        </span>
+                    </div>
+                    <div class="resultado-inputs">
+                        <input type="number" min="0" max="20" class="resultado-input resultado-casa"
+                               value="{% if jogo.gols_casa is not None %}{{ jogo.gols_casa }}{% endif %}"
+                               placeholder="-">
+                        <span class="resultado-x">×</span>
+                        <input type="number" min="0" max="20" class="resultado-input resultado-fora"
+                               value="{% if jogo.gols_fora is not None %}{{ jogo.gols_fora }}{% endif %}"
+                               placeholder="-">
+                        <button class="btn btn-sm btn-primary btn-salvar-resultado" data-jogo-id="{{ jogo.id }}">
+                            <i class="fas fa-check"></i>
+                        </button>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 </div>
 {% endblock %}
 
@@ -185,12 +306,10 @@ const SALVAR_CONFIG_URL = '{% url "bolao:admin_salvar_config" %}';
 const SALVAR_RESULTADO_URL = '{% url "bolao:admin_salvar_resultado" %}';
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Salvar config
     document.getElementById('btn-salvar-config').addEventListener('click', async function() {
         const checks = document.querySelectorAll('.config-check');
         const data = {};
         checks.forEach(c => { data[c.dataset.campo] = c.checked; });
-
         try {
             const resp = await fetch(SALVAR_CONFIG_URL, {
                 method: 'POST',
@@ -199,24 +318,16 @@ document.addEventListener('DOMContentLoaded', function() {
             });
             const result = await resp.json();
             showToast(result.message || 'Salvo!', resp.ok ? 'success' : 'error');
-        } catch (e) {
-            showToast('Erro de conexão', 'error');
-        }
+        } catch (e) { showToast('Erro de conexão', 'error'); }
     });
 
-    // Salvar resultados
     document.querySelectorAll('.btn-salvar-resultado').forEach(btn => {
         btn.addEventListener('click', async function() {
             const jogoId = this.dataset.jogoId;
             const row = this.closest('.resultado-row');
             const casa = row.querySelector('.resultado-casa').value;
             const fora = row.querySelector('.resultado-fora').value;
-
-            if (casa === '' || fora === '') {
-                showToast('Preencha ambos os placares', 'error');
-                return;
-            }
-
+            if (casa === '' || fora === '') { showToast('Preencha ambos os placares', 'error'); return; }
             try {
                 const resp = await fetch(SALVAR_RESULTADO_URL, {
                     method: 'POST',
@@ -228,12 +339,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     showToast(result.message, 'success');
                     this.innerHTML = '<i class="fas fa-check-double"></i>';
                     this.style.background = 'var(--success)';
-                } else {
-                    showToast(result.error, 'error');
-                }
-            } catch (e) {
-                showToast('Erro de conexão', 'error');
-            }
+                } else { showToast(result.error, 'error'); }
+            } catch (e) { showToast('Erro de conexão', 'error'); }
         });
     });
 });

--- a/templates/bolao/home.html
+++ b/templates/bolao/home.html
@@ -55,7 +55,7 @@
             <span>Eliminatórias</span>
         </a>
         {% endif %}
-        {% if config.palpites_publicos %}
+        {% if config.publico_fase_grupos or config.publico_16avos or config.publico_oitavas or config.publico_quartas or config.publico_semi or config.publico_terceiro or config.publico_final %}
         <a href="{% url 'bolao:publico' %}" class="nav-card">
             <i class="fas fa-users"></i>
             <span>Palpites Públicos</span>

--- a/templates/bolao/palpites.html
+++ b/templates/bolao/palpites.html
@@ -16,54 +16,227 @@
 {% block content %}
 <div class="palpites-container">
     <div class="palpites-header">
-        <h2><i class="fas fa-futbol"></i> Palpites — Fase de Grupos</h2>
+        <h2><i class="fas fa-futbol"></i> Meus Palpites</h2>
         <p class="deadline-info">
-            <i class="fas fa-clock"></i> Prazo: <strong>08 de Junho de 2026</strong>
+            <i class="fas fa-clock"></i> Prazo fase de grupos: <strong>08 de Junho de 2026</strong>
         </p>
     </div>
 
-    {% if not config.fase_grupos_aberta %}
-    <div class="alert alert-warning">
-        <i class="fas fa-lock"></i> Os palpites da fase de grupos estão fechados.
-    </div>
-    {% endif %}
+    <!-- ===== FASE DE GRUPOS ===== -->
+    <div class="etapa-section" id="etapa-grupos">
+        <div class="etapa-header etapa-toggle" data-target="etapa-grupos-content">
+            <h3><i class="fas fa-layer-group"></i> Fase de Grupos</h3>
+            <div class="etapa-header-right">
+                {% if fase_grupos_bloqueada %}
+                <span class="badge badge-error"><i class="fas fa-lock"></i> Bloqueada</span>
+                {% elif config.fase_grupos_aberta %}
+                <span class="badge badge-success"><i class="fas fa-unlock"></i> Aberta</span>
+                {% else %}
+                <span class="badge badge-warning"><i class="fas fa-lock"></i> Fechada</span>
+                {% endif %}
+                <i class="fas fa-chevron-down toggle-icon"></i>
+            </div>
+        </div>
+        <div class="etapa-content" id="etapa-grupos-content">
+            {% if not config.fase_grupos_aberta %}
+            <div class="alert alert-warning" style="margin: 1rem 0 0;">
+                <i class="fas fa-lock"></i> Os palpites da fase de grupos estão fechados.
+            </div>
+            {% elif fase_grupos_bloqueada %}
+            <div class="alert alert-error" style="margin: 1rem 0 0;">
+                <i class="fas fa-lock"></i> A fase de grupos está bloqueada. Não é possível enviar ou editar palpites.
+            </div>
+            {% endif %}
 
-    <div class="grupos-grid">
-        {% for grupo in grupos %}
-        <div class="grupo-card" id="grupo-{{ grupo.letra }}">
-            <div class="grupo-header">
-                <h3>Grupo {{ grupo.letra }}</h3>
-                <span class="grupo-status" id="status-{{ grupo.letra }}">
-                    <i class="fas fa-circle"></i> Pendente
-                </span>
+            <div class="grupos-grid">
+                {% for grupo in grupos %}
+                <div class="grupo-card" id="grupo-{{ grupo.letra }}">
+                    <div class="grupo-header">
+                        <h3>Grupo {{ grupo.letra }}</h3>
+                        <span class="grupo-status" id="status-{{ grupo.letra }}">
+                            <i class="fas fa-circle"></i> Pendente
+                        </span>
+                    </div>
+
+                    <div class="jogos-list">
+                        {% for jogo in grupo.jogos.all %}
+                        <div class="jogo-row" data-jogo-id="{{ jogo.id }}" data-grupo="{{ grupo.letra }}"
+                             data-casa-id="{{ jogo.selecao_casa.id }}" data-fora-id="{{ jogo.selecao_fora.id }}">
+                            <div class="jogo-data">
+                                {{ jogo.data_hora|date:"d/m H:i" }}
+                            </div>
+                            <div class="jogo-times">
+                                <div class="time-casa">
+                                    <img src="{% static jogo.selecao_casa|flag_url %}" alt="{{ jogo.selecao_casa.codigo }}" class="bandeira-img">
+                                    <span class="time-nome">{{ jogo.selecao_casa.nome }}</span>
+                                </div>
+                                <div class="placar-inputs">
+                                    <input type="number" min="0" max="9" class="placar-input gols-casa"
+                                           data-jogo="{{ jogo.id }}" data-tipo="casa"
+                                           {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                                    <span class="placar-x">×</span>
+                                    <input type="number" min="0" max="9" class="placar-input gols-fora"
+                                           data-jogo="{{ jogo.id }}" data-tipo="fora"
+                                           {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                                </div>
+                                <div class="time-fora">
+                                    <span class="time-nome">{{ jogo.selecao_fora.nome }}</span>
+                                    <img src="{% static jogo.selecao_fora|flag_url %}" alt="{{ jogo.selecao_fora.codigo }}" class="bandeira-img">
+                                </div>
+                            </div>
+                            {% if jogo.resultado_definido %}
+                            <div class="resultado-oficial">
+                                <span class="resultado-label">Resultado:</span>
+                                <span class="resultado-placar">{{ jogo.gols_casa }} × {{ jogo.gols_fora }}</span>
+                            </div>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                    </div>
+
+                    <div class="classificacao-grupo" id="classificacao-{{ grupo.letra }}">
+                        <h4><i class="fas fa-trophy"></i> Classificação Esperada</h4>
+                        <table class="tabela-classificacao">
+                            <thead>
+                                <tr>
+                                    <th>#</th><th>Seleção</th><th>P</th><th>V</th><th>E</th><th>D</th><th>GP</th><th>GC</th><th>SG</th><th>1º</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for selecao in grupo.selecoes.all %}
+                                <tr data-selecao-id="{{ selecao.id }}">
+                                    <td class="pos">-</td>
+                                    <td class="sel-nome"><img src="{% static selecao|flag_url %}" alt="{{ selecao.codigo }}" class="bandeira-img-sm"> {{ selecao.nome }}</td>
+                                    <td class="pts">0</td><td class="vit">0</td><td class="emp">0</td><td class="der">0</td>
+                                    <td class="gp">0</td><td class="gc">0</td><td class="sg">0</td>
+                                    <td class="estrela-col">
+                                        <button class="btn-estrela" data-selecao="{{ selecao.id }}" data-grupo="{{ grupo.id }}">
+                                            <i class="far fa-star"></i>
+                                        </button>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                {% endfor %}
             </div>
 
-            <div class="jogos-list">
-                {% for jogo in grupo.jogos.all %}
-                <div class="jogo-row" data-jogo-id="{{ jogo.id }}" data-grupo="{{ grupo.letra }}"
-                     data-casa-id="{{ jogo.selecao_casa.id }}" data-fora-id="{{ jogo.selecao_fora.id }}">
-                    <div class="jogo-data">
-                        {{ jogo.data_hora|date:"d/m H:i" }}
+            <div class="extras-section">
+                <h3><i class="fas fa-medal"></i> Palpites Especiais</h3>
+                <div class="extras-grid">
+                    <div class="extra-card">
+                        <label><i class="fas fa-trophy" style="color: gold;"></i> Campeão</label>
+                        <select class="extra-select" data-tipo="campeao" {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                            <option value="">Selecione...</option>
+                        </select>
                     </div>
+                    <div class="extra-card">
+                        <label><i class="fas fa-medal" style="color: silver;"></i> Vice-Campeão</label>
+                        <select class="extra-select" data-tipo="vice" {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                            <option value="">Selecione...</option>
+                        </select>
+                    </div>
+                    <div class="extra-card">
+                        <label><i class="fas fa-medal" style="color: #cd7f32;"></i> Terceiro Colocado</label>
+                        <select class="extra-select" data-tipo="terceiro" {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                            <option value="">Selecione...</option>
+                        </select>
+                    </div>
+                    <div class="extra-card">
+                        <label><i class="fas fa-thumbs-down"></i> Pior Seleção</label>
+                        <select class="extra-select" data-tipo="pior" {% if not config.fase_grupos_aberta or fase_grupos_bloqueada %}disabled{% endif %}>
+                            <option value="">Selecione...</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+
+            {% if config.fase_grupos_aberta and not fase_grupos_bloqueada %}
+            <div class="salvar-section">
+                <div class="validacao-aviso" id="validacao-aviso" style="display:none;">
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <span id="validacao-texto"></span>
+                </div>
+                <p class="rascunho-info" id="rascunho-info" style="display:none;"></p>
+                <div class="salvar-buttons">
+                    <button class="btn btn-outline btn-lg" id="btn-rascunho">
+                        <i class="fas fa-save"></i> Salvar Rascunho
+                    </button>
+                    <button class="btn btn-primary btn-lg" id="btn-enviar">
+                        <i class="fas fa-paper-plane"></i> Enviar Palpites
+                    </button>
+                </div>
+                <p class="salvar-hint">
+                    <strong>Salvar Rascunho:</strong> guarda no seu navegador para continuar depois.<br>
+                    <strong>Enviar Palpites:</strong> salva definitivamente no servidor (precisa estar tudo preenchido).
+                </p>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- ===== FASES ELIMINATÓRIAS ===== -->
+    {% for fase in todas_fases_elim %}
+    <div class="etapa-section" id="etapa-{{ fase.codigo }}">
+        <div class="etapa-header etapa-toggle" data-target="etapa-{{ fase.codigo }}-content">
+            <h3><i class="fas fa-trophy"></i> {{ fase.nome }}</h3>
+            <div class="etapa-header-right">
+                {% if fase.bloqueada %}
+                <span class="badge badge-error"><i class="fas fa-lock"></i> Bloqueada</span>
+                {% elif fase.aberta %}
+                <span class="badge badge-success"><i class="fas fa-unlock"></i> Aberta</span>
+                {% else %}
+                <span class="badge badge-warning"><i class="fas fa-lock"></i> Fechada</span>
+                {% endif %}
+                <i class="fas fa-chevron-down toggle-icon"></i>
+            </div>
+        </div>
+        <div class="etapa-content" id="etapa-{{ fase.codigo }}-content" style="display: none;">
+            <div class="jogos-list" style="padding: 1rem 0;">
+                {% for jogo in fase.jogos %}
+                <div class="jogo-row jogo-row-elim" data-jogo-id="{{ jogo.id }}"
+                     {% if jogo.equipes_definidas %}data-casa-id="{{ jogo.selecao_casa.id }}" data-fora-id="{{ jogo.selecao_fora.id }}"{% endif %}>
+                    <div class="jogo-data">
+                        Jogo {{ jogo.numero_jogo }} — {{ jogo.data_hora|date:"d/m H:i" }}
+                    </div>
+                    {% if jogo.equipes_definidas %}
                     <div class="jogo-times">
                         <div class="time-casa">
                             <img src="{% static jogo.selecao_casa|flag_url %}" alt="{{ jogo.selecao_casa.codigo }}" class="bandeira-img">
                             <span class="time-nome">{{ jogo.selecao_casa.nome }}</span>
                         </div>
                         <div class="placar-inputs">
-                            <input type="number" min="0" max="9" class="placar-input gols-casa"
+                            <input type="number" min="0" max="9" class="placar-input gols-casa elim-input"
                                    data-jogo="{{ jogo.id }}" data-tipo="casa"
-                                   {% if not config.fase_grupos_aberta %}disabled{% endif %}>
+                                   {% if not fase.aberta or fase.bloqueada %}disabled{% endif %}>
                             <span class="placar-x">×</span>
-                            <input type="number" min="0" max="9" class="placar-input gols-fora"
+                            <input type="number" min="0" max="9" class="placar-input gols-fora elim-input"
                                    data-jogo="{{ jogo.id }}" data-tipo="fora"
-                                   {% if not config.fase_grupos_aberta %}disabled{% endif %}>
+                                   {% if not fase.aberta or fase.bloqueada %}disabled{% endif %}>
                         </div>
                         <div class="time-fora">
                             <span class="time-nome">{{ jogo.selecao_fora.nome }}</span>
                             <img src="{% static jogo.selecao_fora|flag_url %}" alt="{{ jogo.selecao_fora.codigo }}" class="bandeira-img">
                         </div>
                     </div>
+                    {% else %}
+                    <div class="jogo-times jogo-tbd">
+                        <div class="time-casa">
+                            <span class="tbd-icon"><i class="fas fa-question-circle"></i></span>
+                            <span class="time-nome tbd-nome">A definir</span>
+                        </div>
+                        <div class="placar-inputs">
+                            <span class="placar-x tbd-vs">vs</span>
+                        </div>
+                        <div class="time-fora">
+                            <span class="time-nome tbd-nome">A definir</span>
+                            <span class="tbd-icon"><i class="fas fa-question-circle"></i></span>
+                        </div>
+                    </div>
+                    <div class="tbd-desc">{{ jogo.descricao }}</div>
+                    {% endif %}
                     {% if jogo.resultado_definido %}
                     <div class="resultado-oficial">
                         <span class="resultado-label">Resultado:</span>
@@ -74,100 +247,16 @@
                 {% endfor %}
             </div>
 
-            <div class="classificacao-grupo" id="classificacao-{{ grupo.letra }}">
-                <h4><i class="fas fa-trophy"></i> Classificação Esperada</h4>
-                <table class="tabela-classificacao">
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Seleção</th>
-                            <th>P</th>
-                            <th>V</th>
-                            <th>E</th>
-                            <th>D</th>
-                            <th>GP</th>
-                            <th>GC</th>
-                            <th>SG</th>
-                            <th>1º</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for selecao in grupo.selecoes.all %}
-                        <tr data-selecao-id="{{ selecao.id }}">
-                            <td class="pos">-</td>
-                            <td class="sel-nome"><img src="{% static selecao|flag_url %}" alt="{{ selecao.codigo }}" class="bandeira-img-sm"> {{ selecao.nome }}</td>
-                            <td class="pts">0</td>
-                            <td class="vit">0</td>
-                            <td class="emp">0</td>
-                            <td class="der">0</td>
-                            <td class="gp">0</td>
-                            <td class="gc">0</td>
-                            <td class="sg">0</td>
-                            <td class="estrela-col">
-                                <button class="btn-estrela" data-selecao="{{ selecao.id }}" data-grupo="{{ grupo.id }}">
-                                    <i class="far fa-star"></i>
-                                </button>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+            {% if fase.aberta and not fase.bloqueada %}
+            <div class="salvar-section">
+                <button class="btn btn-primary btn-lg btn-salvar-elim" data-fase="{{ fase.codigo }}">
+                    <i class="fas fa-save"></i> Salvar Palpites — {{ fase.nome }}
+                </button>
             </div>
-        </div>
-        {% endfor %}
-    </div>
-
-    <div class="extras-section">
-        <h3><i class="fas fa-medal"></i> Palpites Especiais</h3>
-        <div class="extras-grid">
-            <div class="extra-card">
-                <label><i class="fas fa-trophy" style="color: gold;"></i> Campeão</label>
-                <select class="extra-select" data-tipo="campeao" {% if not config.fase_grupos_aberta %}disabled{% endif %}>
-                    <option value="">Selecione...</option>
-                </select>
-            </div>
-            <div class="extra-card">
-                <label><i class="fas fa-medal" style="color: silver;"></i> Vice-Campeão</label>
-                <select class="extra-select" data-tipo="vice" {% if not config.fase_grupos_aberta %}disabled{% endif %}>
-                    <option value="">Selecione...</option>
-                </select>
-            </div>
-            <div class="extra-card">
-                <label><i class="fas fa-medal" style="color: #cd7f32;"></i> Terceiro Colocado</label>
-                <select class="extra-select" data-tipo="terceiro" {% if not config.fase_grupos_aberta %}disabled{% endif %}>
-                    <option value="">Selecione...</option>
-                </select>
-            </div>
-            <div class="extra-card">
-                <label><i class="fas fa-thumbs-down"></i> Pior Seleção</label>
-                <select class="extra-select" data-tipo="pior" {% if not config.fase_grupos_aberta %}disabled{% endif %}>
-                    <option value="">Selecione...</option>
-                </select>
-            </div>
+            {% endif %}
         </div>
     </div>
-
-    {% if config.fase_grupos_aberta %}
-    <div class="salvar-section">
-        <div class="validacao-aviso" id="validacao-aviso" style="display:none;">
-            <i class="fas fa-exclamation-triangle"></i>
-            <span id="validacao-texto"></span>
-        </div>
-        <p class="rascunho-info" id="rascunho-info" style="display:none;"></p>
-        <div class="salvar-buttons">
-            <button class="btn btn-outline btn-lg" id="btn-rascunho">
-                <i class="fas fa-save"></i> Salvar Rascunho
-            </button>
-            <button class="btn btn-primary btn-lg" id="btn-enviar">
-                <i class="fas fa-paper-plane"></i> Enviar Palpites
-            </button>
-        </div>
-        <p class="salvar-hint">
-            <strong>Salvar Rascunho:</strong> guarda no seu navegador para continuar depois.<br>
-            <strong>Enviar Palpites:</strong> salva definitivamente no servidor (precisa estar tudo preenchido).
-        </p>
-    </div>
-    {% endif %}
+    {% endfor %}
 </div>
 {% endblock %}
 
@@ -177,8 +266,94 @@
     const CLASSIFICACOES_EXISTENTES = {{ classificacoes_existentes|safe }};
     const EXTRAS_EXISTENTES = {{ extras_existentes|safe }};
     const TODAS_SELECOES = {{ todas_selecoes|safe }};
+    const PALPITES_ELIM = {{ palpites_elim_existentes|safe }};
     const CSRF_TOKEN = '{{ csrf_token }}';
     const SALVAR_URL = '{% url "bolao:salvar_palpites" %}';
+    const SALVAR_ELIM_URL = '{% url "bolao:salvar_palpites_eliminatorias" %}';
 </script>
 <script src="{% static 'js/bolao.js' %}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // === Accordion de etapas ===
+    document.querySelectorAll('.etapa-toggle').forEach(header => {
+        header.addEventListener('click', function() {
+            const targetId = this.dataset.target;
+            const content = document.getElementById(targetId);
+            const icon = this.querySelector('.toggle-icon');
+            if (content.style.display === 'none') {
+                content.style.display = 'block';
+                icon.classList.remove('fa-chevron-down');
+                icon.classList.add('fa-chevron-up');
+            } else {
+                content.style.display = 'none';
+                icon.classList.remove('fa-chevron-up');
+                icon.classList.add('fa-chevron-down');
+            }
+        });
+    });
+
+    // Fase de grupos começa expandida
+    const gruposContent = document.getElementById('etapa-grupos-content');
+    if (gruposContent) {
+        gruposContent.style.display = 'block';
+        const gruposIcon = document.querySelector('[data-target="etapa-grupos-content"] .toggle-icon');
+        if (gruposIcon) {
+            gruposIcon.classList.remove('fa-chevron-down');
+            gruposIcon.classList.add('fa-chevron-up');
+        }
+    }
+
+    // === Carregar palpites de eliminatórias ===
+    for (const [jogoId, dados] of Object.entries(PALPITES_ELIM)) {
+        const row = document.querySelector(`.jogo-row-elim[data-jogo-id="${jogoId}"]`);
+        if (row) {
+            const casaInput = row.querySelector('.gols-casa');
+            const foraInput = row.querySelector('.gols-fora');
+            if (dados.gols_casa !== null && casaInput) { casaInput.value = dados.gols_casa; casaInput.classList.add('filled'); }
+            if (dados.gols_fora !== null && foraInput) { foraInput.value = dados.gols_fora; foraInput.classList.add('filled'); }
+        }
+    }
+
+    // === Inputs de eliminatórias ===
+    document.querySelectorAll('.elim-input').forEach(input => {
+        input.addEventListener('input', function() {
+            let val = this.value.replace(/[^0-9]/g, '');
+            if (val.length > 1) val = val.charAt(0);
+            this.value = val;
+            this.classList.toggle('filled', val !== '');
+        });
+        input.addEventListener('focus', function() { this.select(); });
+    });
+
+    // === Salvar eliminatórias por fase ===
+    document.querySelectorAll('.btn-salvar-elim').forEach(btn => {
+        btn.addEventListener('click', async function() {
+            const faseCod = this.dataset.fase;
+            const section = document.getElementById('etapa-' + faseCod + '-content');
+            const palpites = {};
+            section.querySelectorAll('.jogo-row-elim').forEach(row => {
+                const jogoId = row.dataset.jogoId;
+                const casa = row.querySelector('.gols-casa');
+                const fora = row.querySelector('.gols-fora');
+                if (casa && fora && casa.value !== '' && fora.value !== '' && !casa.disabled) {
+                    palpites[jogoId] = { gols_casa: parseInt(casa.value), gols_fora: parseInt(fora.value) };
+                }
+            });
+            this.disabled = true;
+            this.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Salvando...';
+            try {
+                const resp = await fetch(SALVAR_ELIM_URL, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF_TOKEN },
+                    body: JSON.stringify({ palpites }),
+                });
+                const result = await resp.json();
+                showToast(result.message || result.error, resp.ok ? 'success' : 'error');
+            } catch (e) { showToast('Erro de conexão', 'error'); }
+            this.disabled = false;
+            this.innerHTML = `<i class="fas fa-save"></i> Salvar Palpites — ${this.closest('.etapa-section').querySelector('.etapa-header h3').textContent.trim()}`;
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/templates/bolao/publico.html
+++ b/templates/bolao/publico.html
@@ -21,10 +21,14 @@
 
     {% for item in participantes %}
     <div class="participante-card">
-        <div class="participante-card-header">
-            <h3><i class="fas fa-user"></i> {{ item.participante.nome_completo }}</h3>
+        <div class="participante-card-header participante-toggle" data-target="participante-{{ forloop.counter }}">
+            <h3>
+                <i class="fas fa-user"></i> {{ item.participante.nome_completo }}
+                <i class="fas fa-chevron-down toggle-icon"></i>
+            </h3>
         </div>
-        <div class="participante-palpites">
+        <div class="participante-palpites" id="participante-{{ forloop.counter }}" style="display: none;">
+            {% if config.publico_fase_grupos %}
             {% for grupo in grupos %}
             <div class="publico-grupo">
                 <h4>Grupo {{ grupo.letra }}</h4>
@@ -54,8 +58,62 @@
                 </div>
             </div>
             {% endfor %}
+            {% endif %}
+
+            {% for fase in fases_elim_publicas %}
+            <div class="publico-grupo">
+                <h4><i class="fas fa-trophy"></i> {{ fase.nome }}</h4>
+                <div class="publico-jogos">
+                    {% for jogo in fase.jogos %}
+                    {% with palpite=item.palpites %}
+                    <div class="publico-jogo-row">
+                        <span class="publico-time"><img src="{% static jogo.selecao_casa|flag_url %}" alt="" class="bandeira-img-sm"> {{ jogo.selecao_casa.nome }}</span>
+                        <span class="publico-placar">
+                            {% if jogo.id in palpite %}
+                            {{ palpite|get_item:jogo.id|get_nested:"casa" }} × {{ palpite|get_item:jogo.id|get_nested:"fora" }}
+                            {% else %}
+                            - × -
+                            {% endif %}
+                        </span>
+                        <span class="publico-time">{{ jogo.selecao_fora.nome }} <img src="{% static jogo.selecao_fora|flag_url %}" alt="" class="bandeira-img-sm"></span>
+                        {% if jogo.resultado_definido and jogo.id in palpite %}
+                        <span class="publico-pontos">
+                            {% with pts=palpite|get_item:jogo.id|get_nested:"pontos" %}
+                            {% if pts is not None %}+{{ pts }}{% endif %}
+                            {% endwith %}
+                        </span>
+                        {% endif %}
+                    </div>
+                    {% endwith %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
         </div>
     </div>
     {% endfor %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.participante-toggle').forEach(header => {
+        header.addEventListener('click', function() {
+            const targetId = this.dataset.target;
+            const content = document.getElementById(targetId);
+            const icon = this.querySelector('.toggle-icon');
+            if (content.style.display === 'none') {
+                content.style.display = 'block';
+                icon.classList.remove('fa-chevron-down');
+                icon.classList.add('fa-chevron-up');
+            } else {
+                content.style.display = 'none';
+                icon.classList.remove('fa-chevron-up');
+                icon.classList.add('fa-chevron-down');
+            }
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Resumo

- **Senha Admin**: PIN substituido por senha segura
- **Bandeiras PNG**: Dropdowns com flags nas eliminatorias (admin e usuario)
- **Palpites unificados**: Fase de grupos + todas as eliminatorias em uma unica pagina com accordion colapsavel
- **Cadeado por fase**: Admin pode bloquear envio/edicao de palpites por fase
- **Publico por fase**: Admin pode tornar palpites publicos individualmente por fase
- **Palpites publicos**: Accordion por participante (todos minimizados), exibicao de fases eliminatorias publicas
- **Jogos TBD**: Fases eliminatorias sem equipes definidas exibem A definir
- **Home**: Link Palpites Publicos condicional por fase ativa
- **CSS**: Estilos para toggle lock/publico, badge-error, etapa accordion, jogo TBD

## Plano de teste
- [ ] Verificar login admin com nova senha
- [ ] Testar bandeiras PNG na selecao de eliminatorias
- [ ] Verificar accordion nas etapas de palpites
- [ ] Testar cadeado por fase (usuario nao consegue salvar)
- [ ] Testar publico por fase (apenas fases marcadas aparecem)
- [ ] Verificar jogos A definir nas eliminatorias sem equipes

Made with [Cursor](https://cursor.com)