### PR TITLE
fix: CSRF_TRUSTED_ORIGINS para futeletrica.com.br

### DIFF
--- a/futeletrica_site/settings.py
+++ b/futeletrica_site/settings.py
@@ -29,6 +29,11 @@ DEBUG = True
 # ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
+CSRF_TRUSTED_ORIGINS = os.getenv(
+    "CSRF_TRUSTED_ORIGINS",
+    "https://www.futeletrica.com.br,https://futeletrica.com.br"
+).split(",")
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Adiciona CSRF_TRUSTED_ORIGINS no settings.py para permitir requests POST do dominio https://www.futeletrica.com.br e https://futeletrica.com.br. Sem isso, qualquer form POST (login admin, salvar palpites, etc.) retorna erro 403 Forbidden.

Made with [Cursor](https://cursor.com)