### PR TITLE
fix: desativar bloqueio automatico de palpites por data/hora

### DIFF
--- a/bolao/prazos.py
+++ b/bolao/prazos.py
@@ -38,9 +38,13 @@ def get_prazo(fase):
 
 
 def prazo_passou(fase):
-    """True se o prazo da fase já passou."""
-    prazo = get_prazo(fase)
-    return prazo is not None and timezone.now() > prazo
+    """Bloqueio automático por data/hora DESATIVADO (hotfix 28/06/2026).
+
+    O controle de bloqueio/desbloqueio das fases é feito exclusivamente pelo
+    admin (campos lock_* da ConfigBolao). Os prazos continuam sendo exibidos
+    apenas como informação, mas não bloqueiam mais os palpites automaticamente.
+    """
+    return False
 
 
 def prazo_label(fase):


### PR DESCRIPTION
## Summary
- Desativa o bloqueio automatico de palpites por data/hora (`prazo_passou()` passa a retornar sempre `False`).
- O controle de bloqueio/desbloqueio das fases fica exclusivamente com o admin via campos `lock_*` da `ConfigBolao`.
- Os prazos continuam exibidos nas telas apenas como informacao, sem impedir envio ou edicao de palpites.
- Hotfix para liberar a fase de 16-avos, que havia sido bloqueada automaticamente em 27/06 com confrontos ainda pendentes.

## Test plan
- [ ] Fazer deploy da branch `bolao` em producao
- [ ] No painel admin, confirmar que desativar o cadeado de 16-avos libera os palpites pendentes
- [ ] Verificar que participantes conseguem salvar palpites da fase de 16-avos
- [ ] Confirmar que ativar o cadeado manual no admin continua bloqueando a fase corretamente
- [ ] Confirmar que os prazos ainda aparecem nas regras e na tela de palpites (somente informativos)
